### PR TITLE
ci: add GHCR arm64 build/push workflow, slim Dockerfile

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,36 @@
+name: tthol linebot CI
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v7
+      - name: Log in to GHCR
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Build and push Docker image
+        # No test gate: the repository's current Jest suite has broken empty suites.
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
+        with:
+          context: .
+          platforms: linux/arm64
+          push: true
+          tags: |
+            ghcr.io/hanshino/tthol-line-bot:latest
+            ghcr.io/hanshino/tthol-line-bot:${{ github.sha }}
+          cache-from: type=registry,ref=ghcr.io/hanshino/tthol-line-bot:buildcache
+          cache-to: type=registry,ref=ghcr.io/hanshino/tthol-line-bot:buildcache,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts
+FROM node:lts-bullseye-slim
 
 LABEL Name="tthol Line機器人"
 LABEL description="非官方，純玩家興趣而寫的機器人"
@@ -10,7 +10,7 @@ WORKDIR /application
 COPY package.json ./
 COPY yarn.lock ./
 
-RUN yarn install
+RUN yarn install --frozen-lockfile --production
 
 ENV NODE_ENV=production
 


### PR DESCRIPTION
## 這個 PR 做的事

1. **新增 `.github/workflows/main.yml`** — push 到 `master` 時，用 native `ubuntu-24.04-arm` runner build+push `linux/arm64` image 到 `ghcr.io/hanshino/tthol-line-bot`（tag `:latest` + `:${{ github.sha }}`），用 registry cache。沒有 test gate（現有 jest suite 本來就是紅的，跟這次改動無關）、沒有 deploy job（部署仍是手動）。
2. **Dockerfile 瘦身** — base image 從 `node:lts` 改成 `node:lts-bullseye-slim`（對齊同家族的 `tthol_bot`），`yarn install` 加上 `--frozen-lockfile --production`。

## Runtime 契約（未變更）
- WORKDIR `/application`
- Port `5000`
- `CMD [ "yarn", "start" ]`
- 環境變數名稱（`NODE_ENV`/`PORT`/`TTHOL_DATABASE`/`LINE_ACCESS_TOKEN`/`LINE_CHANNEL_SECRET`/`EQUIP_SHEET_*`）

## 驗證
- `docker build` 本機過，image `1.68GB → 729MB`（-56%）
- `docker run` 本機起得來：`yarn start` → `node server.js`，正常監聽 5000，掛載 `storage/tthol.sqlite:ro` 正常讀取
- YAML 用 js-yaml 驗證過語法
- arm64 build 在本機 sandbox 沒有 emulation 跑不了，但 workflow 用的是 native arm64 runner，不受影響

## 需要手動做的事
- [ ] merge 後第一次 push，GHCR package `ghcr.io/hanshino/tthol-line-bot` 預設是 private，要手動去 package settings 改成 Public（否則機器上匿名 pull 會失敗）
- [ ] 機器上 compose 把 `build:` 換成 `image: ghcr.io/hanshino/tthol-line-bot:latest`
- [ ] 確認 manifest 含 arm64：`docker manifest inspect ghcr.io/hanshino/tthol-line-bot:latest`
