### PR TITLE
fix: display correct skill hit rate

### DIFF
--- a/src/app/controllers/magicController.js
+++ b/src/app/controllers/magicController.js
@@ -5,8 +5,9 @@ const magicTemplate = require("../templates/magicTemplate");
 let skillRegex = /^.(skill|技能)\s(?<id>\d+)(\s(?<level>\d+))?/;
 // 數值參數只挑這幾個乾淨欄位（比照 mockup），避免 break_prob/group/order/status_prob 等
 // 內部除錯欄位（locale 裡沒有真中文翻譯，只是把英文欄名原樣複製一份）混進來顯示。
-const STAT_KEYS = ["range", "spend_mp", "stun", "time", "func_dmg", "func_hit"];
+const STAT_KEYS = ["range", "spend_mp", "stun", "time", "func_dmg", "func_hit_p1"];
 exports.routes = [text(skillRegex, showSkill), text(/^\.?(skill|技能)\s/, searchSkill)];
+exports.showSkill = showSkill;
 
 /**
  * 技能搜尋
@@ -65,13 +66,15 @@ async function showSkill(context, props) {
         key === "pk_disable" && magic[key] ? "#b6322d" : undefined
       )
     );
-  const statRows = STAT_KEYS.filter(key => magic[key] !== undefined && magic[key] !== null).map(
+  const statRows = STAT_KEYS.filter(
     key =>
-      magicTemplate.genAttributeRow(
-        i18n.__("magic." + key),
-        magic[key],
-        magicTemplate.valueColor(key)
-      )
+      magic[key] !== undefined && magic[key] !== null && (key !== "func_hit_p1" || magic[key] !== 0)
+  ).map(key =>
+    magicTemplate.genAttributeRow(
+      key === "func_hit_p1" ? "命中率" : i18n.__("magic." + key),
+      key === "func_hit_p1" ? `${magic[key]}%` : magic[key],
+      magicTemplate.valueColor(key)
+    )
   );
   let bubbles = [magicTemplate.genMagicBubble(magic, basicRows, statRows)];
   let max = await magicService.getMaxLevelById(id);

--- a/src/app/controllers/magicController.test.js
+++ b/src/app/controllers/magicController.test.js
@@ -1,0 +1,73 @@
+jest.mock("../services/magicService", () => ({
+  find: jest.fn(),
+  getMaxLevelById: jest.fn(),
+}));
+
+const magicService = require("../services/magicService");
+const { showSkill } = require("./magicController");
+
+function contextFor(replyFlex) {
+  return {
+    replyFlex,
+    replyText: jest.fn(),
+  };
+}
+
+describe("magicController.showSkill", () => {
+  beforeEach(() => {
+    magicService.find.mockResolvedValue({
+      id: 4,
+      level: 1,
+      name: "怒擊",
+      func_hit: 1,
+      func_hit_p1: 95,
+    });
+    magicService.getMaxLevelById.mockResolvedValue({ level: 1 });
+  });
+
+  it("shows func_hit_p1 as a percentage instead of the opcode", async () => {
+    let message;
+    await showSkill(
+      contextFor((_, payload) => {
+        message = payload;
+      }),
+      { match: { groups: { id: 4, level: 1 } } }
+    );
+
+    const output = JSON.stringify(message);
+    expect(output).toContain("命中率");
+    expect(output).toContain("95%");
+    expect(
+      message.contents[0].body.contents
+        .flatMap(section => section.contents || [])
+        .some(
+          row =>
+            row.contents &&
+            row.contents[0] &&
+            row.contents[1] &&
+            row.contents[0].text === "命中率" &&
+            row.contents[1].text === "95%"
+        )
+    ).toBe(true);
+    expect(output).not.toContain('"text":"命中率","color":"#585e68"},{"type":"text","text":"1"');
+  });
+
+  it.each([null, 0])("hides func_hit_p1 when it is %s", async hitRate => {
+    magicService.find.mockResolvedValue({
+      id: 4,
+      level: 1,
+      name: "怒擊",
+      func_hit: 1,
+      func_hit_p1: hitRate,
+    });
+    let message;
+    await showSkill(
+      contextFor((_, payload) => {
+        message = payload;
+      }),
+      { match: { groups: { id: 4, level: 1 } } }
+    );
+
+    expect(JSON.stringify(message)).not.toContain("命中率");
+  });
+});


### PR DESCRIPTION
## Summary

技能 Flex Message 現在顯示實際命中率參數，例如「怒擊 Lv1」會顯示 `95%`，不再把內部 `func_hit` opcode 顯示成命中率。

`func_hit_p1` 為 `null` 或 `0` 時會隱藏命中率列，避免顯示誤導資訊；其他技能屬性與版面維持不變。

## Verification

- `TTHOL_DATABASE=dummy.sqlite yarn test src/ --runInBand`：2 suites、4 tests passed
- `npx eslint .`：passed
- 使用真實 SQLite「怒擊 Lv1」產生 Flex payload，LINE `/v2/bot/message/validate/reply`：HTTP 200
